### PR TITLE
Running sbt assembly, it gave errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ version := "0.1"
 
 scalaVersion := "2.11.12"
 
-resolvers += "Restlet Repository" at "http://maven.restlet.org"
-resolvers += "Spark Packages Repo" at "http://dl.bintray.com/spark-packages/maven"
+resolvers += "Restlet Repository" at "https://maven.restlet.talend.com"
+resolvers += "Spark Packages Repo" at "https://repos.spark-packages.org"
 
 // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.2.1
+sbt.version=1.6.2
+


### PR DESCRIPTION
Running sbt assembly, gave errors. Fix these two errors:
1. [error] [launcher] error during sbt launcher: java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
2. [error] (scalaCompilerBridgeScope / csrConfiguration) insecure protocol is unsupported"